### PR TITLE
chore: bump marked  version from 0.8.0 to 7.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ink-markdown",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Render markdown text using Ink",
   "main": "./build/index.js",
   "author": "Cameron Hunter <hello@cameronhunter.co.uk>",
@@ -29,7 +29,7 @@
     "./build"
   ],
   "dependencies": {
-    "marked": "^0.8.0",
+    "marked": "^7.0.5",
     "marked-terminal": "^4.0.0"
   },
   "devDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,5 +9,5 @@ type Props = TerminalRendererOptions & {
 
 export default function Markdown({ children, ...options }: Props) {
   marked.setOptions({ renderer: new TerminalRenderer(options) });
-  return <Text>{marked(children).trim()}</Text>;
+  return <Text>{marked.parse(children).trim()}</Text>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2370,10 +2370,10 @@ marked-terminal@^4.0.0:
     node-emoji "^1.10.0"
     supports-hyperlinks "^2.0.0"
 
-marked@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.0.tgz#ec5c0c9b93878dc52dd54be8d0e524097bd81a99"
-  integrity sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==
+marked@^7.0.5:
+  version "7.0.5"
+  resolved "http://bnpm.byted.org/marked/-/marked-7.0.5.tgz#8a9e4e3afb93b58fe9ee7608e67cc154eb15d508"
+  integrity sha512-lwNAFTfXgqpt/XvK17a/8wY9/q6fcSPZT1aP6QW0u74VwaJF/Z9KbRcX23sWE4tODM+AolJNcUtErTkgOeFP/Q==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
upgrade deps version  ，because of  [security vulnerabilities](https://security.snyk.io/vuln/npm?search=marked)